### PR TITLE
InvalidMove fix

### DIFF
--- a/blanc_basic_pages/admin.py
+++ b/blanc_basic_pages/admin.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django_mptt_admin.admin import DjangoMpttAdmin
 
-from .forms import page_admin_form
+from .forms import PageAdminForm
 from .models import Page
 
 
@@ -29,4 +29,4 @@ class PageAdmin(DjangoMpttAdmin):
     list_display = ('url', 'title') + (('login_required',) if SHOW_LOGIN_REQUIRED else ())
     list_filter = ('published',) + (('login_required',) if SHOW_LOGIN_REQUIRED else ())
     search_fields = ('url', 'title')
-    form = page_admin_form()
+    form = PageAdminForm

--- a/blanc_basic_pages/forms.py
+++ b/blanc_basic_pages/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.conf import settings
 
+from mptt.forms import MPTTAdminForm
+
 from .models import Page
 
 
@@ -9,7 +11,7 @@ TEMPLATE_CHOICES = getattr(settings, 'PAGE_TEMPLATES', (
 ))
 
 
-class PageAdminForm(forms.ModelForm):
+class PageAdminForm(MPTTAdminForm):
     class Meta:
         model = Page
         exclude = ()

--- a/blanc_basic_pages/forms.py
+++ b/blanc_basic_pages/forms.py
@@ -9,14 +9,14 @@ TEMPLATE_CHOICES = getattr(settings, 'PAGE_TEMPLATES', (
 ))
 
 
-class BasePageAdminForm(forms.ModelForm):
+class PageAdminForm(forms.ModelForm):
     class Meta:
         model = Page
         exclude = ()
 
+    def __init__(self, *args, **kwargs):
+        super(PageAdminForm, self).__init__(*args, **kwargs)
 
-def page_admin_form():
-    class PageAdminForm(BasePageAdminForm):
-        template_name = forms.ChoiceField(choices=TEMPLATE_CHOICES, required=False)
-
-    return PageAdminForm
+        # The list of templates is defined in settings, however as we can't have dynamic choices in
+        # models due to migrations - we change the form choices instead.
+        self.fields['template_name'] = forms.ChoiceField(choices=TEMPLATE_CHOICES, required=False)

--- a/blanc_basic_pages/forms.py
+++ b/blanc_basic_pages/forms.py
@@ -15,10 +15,8 @@ class PageAdminForm(MPTTAdminForm):
     class Meta:
         model = Page
         exclude = ()
-
-    def __init__(self, *args, **kwargs):
-        super(PageAdminForm, self).__init__(*args, **kwargs)
-
-        # The list of templates is defined in settings, however as we can't have dynamic choices in
-        # models due to migrations - we change the form choices instead.
-        self.fields['template_name'] = forms.ChoiceField(choices=TEMPLATE_CHOICES, required=False)
+        widgets = {
+            # The list of templates is defined in settings, however as we can't have dynamic
+            # choices in models due to migrations - we change the form choices instead.
+            'template_name': forms.widgets.Select(choices=TEMPLATE_CHOICES),
+        }


### PR DESCRIPTION
This will prevent users picking invalid options which results in:

```
InvalidMove: A node may not be made a child of itself.
```

Closes #4 