### PR TITLE
Form settings (hero image)

### DIFF
--- a/blanc_basic_pages/admin.py
+++ b/blanc_basic_pages/admin.py
@@ -15,7 +15,11 @@ class PageAdmin(DjangoMpttAdmin):
     form = PageAdminForm
 
     def get_fieldsets(self, request, obj=None):
+        content = ['hero_image', 'content']
         advanced_options = ['template_name', 'published', 'login_required']
+
+        if not getattr(settings, 'PAGE_SHOW_HERO_IMAGE', True):
+            content.remove('hero_image')
 
         if not SHOW_LOGIN_REQUIRED:
             advanced_options.remove('login_required')
@@ -28,7 +32,7 @@ class PageAdmin(DjangoMpttAdmin):
                 'fields': ('parent', 'show_in_navigation'),
             }),
             ('Content', {
-                'fields': ('hero_image', 'content'),
+                'fields': content,
             }),
             ('Advanced options', {
                 'fields': advanced_options,

--- a/blanc_basic_pages/admin.py
+++ b/blanc_basic_pages/admin.py
@@ -11,22 +11,43 @@ SHOW_LOGIN_REQUIRED = getattr(settings, 'PAGE_SHOW_LOGIN', False)
 
 @admin.register(Page)
 class PageAdmin(DjangoMpttAdmin):
-    fieldsets = (
-        (None, {
-            'fields': ('url', 'title')
-        }),
-        ('Navigation', {
-            'fields': ('parent', 'show_in_navigation')
-        }),
-        ('Content', {
-            'fields': ('hero_image', 'content',)
-        }),
-        ('Advanced options', {
-            'fields': ('template_name', 'published') +
-                      (('login_required',) if SHOW_LOGIN_REQUIRED else ()),
-        }),
-    )
-    list_display = ('url', 'title') + (('login_required',) if SHOW_LOGIN_REQUIRED else ())
-    list_filter = ('published',) + (('login_required',) if SHOW_LOGIN_REQUIRED else ())
     search_fields = ('url', 'title')
     form = PageAdminForm
+
+    def get_fieldsets(self, request, obj=None):
+        advanced_options = ['template_name', 'published', 'login_required']
+
+        if not SHOW_LOGIN_REQUIRED:
+            advanced_options.remove('login_required')
+
+        fieldsets = (
+            (None, {
+                'fields': ('url', 'title'),
+            }),
+            ('Navigation', {
+                'fields': ('parent', 'show_in_navigation'),
+            }),
+            ('Content', {
+                'fields': ('hero_image', 'content'),
+            }),
+            ('Advanced options', {
+                'fields': advanced_options,
+            }),
+        )
+        return fieldsets
+
+    def get_list_display(self, request):
+        list_display = ['url', 'title', 'login_required']
+
+        if not SHOW_LOGIN_REQUIRED:
+            list_display.remove('login_required')
+
+        return list_display
+
+    def get_list_filter(self, request):
+        list_filter = ['published', 'login_required']
+
+        if not SHOW_LOGIN_REQUIRED:
+            list_filter.remove('login_required')
+
+        return list_filter

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -34,3 +34,12 @@ password authentication - so we hide it.
 If your site needs certain pages to be protected so that only logged-in users
 are able to view them, change this to ``True`` and then the option will appear
 in the Django admin.
+
+PAGE_SHOW_HERO_IMAGE
+====================
+
+Default: ``True``
+
+Shows or hides the *Hero Image* field for pages in the Django admin. By default
+this is ``True``, however if the site has no need for hero images in pages then
+this can be turned off.


### PR DESCRIPTION
This adds another setting to allow us to disable the hero image field from the pages admin.

Some older sites don't have them, or need them. Upgrading old sites to fix bugs and adding an unexpected field might confuse them - so this toggle allows us to turn it off.